### PR TITLE
[FIX|IMP] Combiner Method Args & ReadMe Updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,19 @@ A simple example would look like:
    from reverend.thomas import Bayes
 
    guesser = Bayes()
+
    guesser.train('fish', 'salmon trout cod carp')
    guesser.train('fowl', 'hen chicken duck goose')
 
    guesser.guess('chicken tikka marsala')
+   #  Returns
+   #  [('fowl', 0.9999)]
 
-   You can also "forget" some training:
+
+You can also "forget" some training:
+
+.. code-block:: python
+
    guesser.untrain('fish', 'salmon carp')
 
 The first argument of ``train`` is the bucket or class that
@@ -36,7 +43,6 @@ The second argument is the object that you want Bayes to be
 trained on. By default, Bayes expects a string and uses something
 like ``string.split`` to break it into individual tokens (words).
 It uses these tokens as the basis of its bookkeeping.
-
 
 The two ways to extend it are:
 
@@ -51,6 +57,8 @@ The two ways to extend it are:
 
 Known Issues / Road Map
 =======================
+
+* Not compatible with Python 3
 
 Credits
 =======

--- a/reverend/tests/test_thomas.py
+++ b/reverend/tests/test_thomas.py
@@ -3,20 +3,29 @@
 Tests for L{reverend.thomas}.
 """
 
-from twisted.trial.unittest import TestCase
+from unittest import TestCase
 
 from reverend.thomas import Bayes
 
 
-class BayesTests(TestCase):
+class TestThomas(TestCase):
     """
     Tests for L{Bayes}.
     """
 
-    def test_untrained_guess(self):
-        """
-        The C{guess} method of a L{Bayes} instance with no training data returns
-        an empty list.
-        """
-        bayes = Bayes()
-        self.assertEquals(bayes.guess("hello, world"), [])
+    def setUp(self):
+        super(TestThomas, self).setUp()
+        self.bayes = Bayes()
+
+    def test_guess_untrained(self):
+        """It should return an empty list when not trained."""
+        self.assertEquals(self.bayes.guess("hello, world"), [])
+
+    def test_guess_trained(self):
+        """It should return the proper guess when trained."""
+        self.bayes.train('fish', 'salmon trout cod carp')
+        self.bayes.train('fowl', 'hen chicken duck goose')
+        self.assertEquals(
+            self.bayes.guess('chicken tikka marsala'),
+            [('fowl', 0.9999)],
+        )

--- a/reverend/thomas.py
+++ b/reverend/thomas.py
@@ -270,20 +270,35 @@ class Bayes(object):
                 return True
         return False
 
-    def guess(self, msg):
-        tokens = set(self.get_tokens(msg))
+    def guess(self, message):
+        """Guess which buckets the message belongs to.
+
+        Args:
+            message (str): The message string to tokenize and subsequently
+            classify.
+
+        Returns:
+            list of tuple: List of tuple pairs indicating which bucket(s) the
+            message string is guessed to be classified under, and the ratio of
+            certainty for this guess. As an example, a 99% probability that
+            the input is a ``fowl`` would look like ``[('fowl', 0.9999)]``.
+        """
+
+        tokens = set(self.get_tokens(message))
         pools = self.pool_probs()
 
         res = {}
-        for pname, pprobs in pools.items():
-            p = self.get_probs(pprobs, tokens)
-            if len(p) != 0:
-                res[pname]=self.combiner(p, pname)
+        for pool_name, pool_probs in pools.items():
+            p = self.get_probs(pool_probs, tokens)
+            if len(p):
+                res[pool_name] = self.combiner(p, pool_name)
+
         res = res.items()
-        res.sort(lambda x,y: cmp(y[1], x[1]))
+        res.sort(lambda x, y: cmp(y[1], x[1]))
         return res
 
-    def robinson(self, probs):
+    @staticmethod
+    def robinson(probs, _):
         """Computes the probability of a message being spam (Robinson's method)
             P = 1 - prod(1-p)^(1/n)
             Q = 1 - prod(p)^(1/n)
@@ -297,7 +312,8 @@ class Bayes(object):
         S = (P - Q) / (P + Q)
         return (1 + S) / 2
 
-    def robinson_fisher(self, probs):
+    @staticmethod
+    def robinson_fisher(probs, _):
         """Computes the probability of a message being spam (Robinson-Fisher method)
             H = C-1( -2.ln(prod(p)), 2*n )
             S = C-1( -2.ln(prod(1-p)), 2*n )


### PR DESCRIPTION
[FIX] Unexpected args sent to combiner method …
* Refactor `quess` for better variable names 
* Add docblock for `guess`
 * Change ronbinson methods to static 
* Add unused pool name arg to robinson methods, which should conform to the combiner API
* Switch to standard unittest instead of twisted


[IMP] ReadMe: Example and Py3 incompatibility 
* Update example to include a return
* Split example parts into two sections
* Py3 incompatibility to known issues